### PR TITLE
Pipe

### DIFF
--- a/Homero.Plugin.Pipe/Homero.Plugin.Pipe.csproj
+++ b/Homero.Plugin.Pipe/Homero.Plugin.Pipe.csproj
@@ -1,0 +1,70 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{B9F15209-14FA-49C1-A5D9-1D15E676E8F3}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Homero.Plugin.Pipe</RootNamespace>
+    <AssemblyName>Homero.Plugin.Pipe</AssemblyName>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>..\Homero\bin\Debug\Plugins\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Ninject, Version=3.2.0.0, Culture=neutral, PublicKeyToken=c7192dc5380945e7, processorArchitecture=MSIL">
+      <HintPath>..\packages\Ninject.3.2.2.0\lib\net45-full\Ninject.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="PipeClient.cs" />
+    <Compile Include="PipeModule.cs" />
+    <Compile Include="PipePlugin.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Homero\Homero.csproj">
+      <Project>{ff9f1cd6-7472-452c-aa36-a0ebf6014dd3}</Project>
+      <Name>Homero</Name>
+      <Private>False</Private>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Homero.Plugin.Pipe/PipeClient.cs
+++ b/Homero.Plugin.Pipe/PipeClient.cs
@@ -1,0 +1,151 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Homero.Client;
+using Homero.EventArgs;
+using Homero.Messages;
+using Homero.Messages.Attachments;
+using Homero.Services;
+
+namespace Homero.Plugin.Pipe
+{
+    /// <exclude />
+    public class PipeClient : IClient
+    {
+        private IClient _innerClient;
+        private MessageBrokerService _messageBroker;
+        public List<string> _commandChain = new List<string>();
+        private ITextCommand _innerCommand;
+        public PipeClient(IClient innerClient, IMessageBroker broker, ITextCommand innerCommand)
+        {
+            _innerCommand = innerCommand;
+            _innerClient = innerClient;
+            _messageBroker = broker as MessageBrokerService; // oops im breaking IoC for this, todo: expose invocation over standard interface
+        }
+        public string Name
+        {
+            get { return "Pipe Client"; }
+        }
+
+        public string Description
+        {
+            get { return "A mock client to handle plugins jibber jabbering back and forth."; }
+        }
+
+        public Version Version { get; }
+
+        public bool MarkdownSupported
+        {
+            get { return _innerClient.MarkdownSupported; }
+        }
+
+        public bool AudioSupported
+        {
+            get { return _innerClient.AudioSupported; }
+        }
+
+        public bool IrcFormattingSupported
+        {
+            get { return _innerClient.IrcFormattingSupported; }
+        }
+
+        public bool InlineOrOembedSupported
+        {
+            get { return _innerClient.InlineOrOembedSupported; }
+        }
+
+        public Task<bool> Connect()
+        {
+            return null;
+        }
+
+        public void FireFirstMessage(ITextCommand command)
+        {
+            _messageBroker.RaiseCommandReceived(this, command);
+        }
+
+        public Task DispatchMessage(IStandardMessage message)
+        {
+            return null;
+        }
+
+        public void ReplyTo(IStandardMessage originalMessage, string reply)
+        {
+            // pignored
+        }
+
+        public void ReplyTo(IStandardMessage originalMessage, IAttachment attachment)
+        {
+            // dignored
+        }
+
+        public void ReplyTo(IStandardMessage originalMessage, string reply, IAttachment attachment)
+        {
+            // engored
+        }
+
+        public void ReplyTo(IStandardMessage originalMessage, string reply, List<IAttachment> attachments)
+        {
+            // ig-ghored
+        }
+
+        public void ReplyTo(IStandardMessage originalMessage, IStandardMessage reply)
+        {
+            // ignored u think i give a care?
+        }
+
+        public void ReplyTo(ITextCommand originalCommand, string reply)
+        {
+            if (_commandChain.Count == 0)
+            {
+                _innerClient.ReplyTo(_innerCommand, reply);
+            }
+            else
+            {
+                StandardMessage curMessage = new StandardMessage()
+                {
+                    /*
+                    Attachments = originalCommand.InnerMessage.Attachments,
+                    Channel = originalCommand.InnerMessage.Channel,
+                    IsPrivate = originalCommand.InnerMessage.IsPrivate,
+                    Message = reply,
+                    Sender = originalCommand.InnerMessage.Sender,
+                    Server = originalCommand.InnerMessage.Server,
+                    Target = originalCommand.InnerMessage.Target
+                    */
+                };
+                
+                TextCommand newCommand = new TextCommand();
+                newCommand.InnerMessage = curMessage;
+                newCommand.Command = _commandChain.First();
+                newCommand.Arguments = reply.Split(' ').ToList();
+                _commandChain.RemoveAt(0);
+                _messageBroker.RaiseCommandReceived(this, newCommand);
+            }
+        }
+
+        public void ReplyTo(ITextCommand originalCommand, string reply, IAttachment attachment)
+        {
+            // ig a nore
+        }
+
+        public void ReplyTo(ITextCommand originalCommand, IAttachment attachment)
+        {
+        }
+
+        public void ReplyTo(ITextCommand originalCommand, string reply, List<IAttachment> attachments)
+        {
+        }
+
+        public void ReplyTo(ITextCommand originalCommand, IStandardMessage reply)
+        {
+            // u also get ignored
+        }
+
+        public bool IsConnected { get { return true; } }
+        public event EventHandler<MessageReceivedEventArgs> MessageReceived;
+        public event EventHandler<MessageSentEventArgs> MessageSent;
+    }
+}

--- a/Homero.Plugin.Pipe/PipeClient.cs
+++ b/Homero.Plugin.Pipe/PipeClient.cs
@@ -16,8 +16,9 @@ namespace Homero.Plugin.Pipe
     {
         private IClient _innerClient;
         private MessageBrokerService _messageBroker;
-        public List<string> _commandChain = new List<string>();
         private ITextCommand _innerCommand;
+
+        public List<string> CommandChain { get; set; }
         public PipeClient(IClient innerClient, IMessageBroker broker, ITextCommand innerCommand)
         {
             _innerCommand = innerCommand;
@@ -98,30 +99,16 @@ namespace Homero.Plugin.Pipe
 
         public void ReplyTo(ITextCommand originalCommand, string reply)
         {
-            if (_commandChain.Count == 0)
+            if (CommandChain.Count == 0)
             {
                 _innerClient.ReplyTo(_innerCommand, reply);
             }
             else
             {
-                StandardMessage curMessage = new StandardMessage()
-                {
-                    /*
-                    Attachments = originalCommand.InnerMessage.Attachments,
-                    Channel = originalCommand.InnerMessage.Channel,
-                    IsPrivate = originalCommand.InnerMessage.IsPrivate,
-                    Message = reply,
-                    Sender = originalCommand.InnerMessage.Sender,
-                    Server = originalCommand.InnerMessage.Server,
-                    Target = originalCommand.InnerMessage.Target
-                    */
-                };
-                
                 TextCommand newCommand = new TextCommand();
-                newCommand.InnerMessage = curMessage;
-                newCommand.Command = _commandChain.First();
+                newCommand.Command = CommandChain.First();
                 newCommand.Arguments = reply.Split(' ').ToList();
-                _commandChain.RemoveAt(0);
+                CommandChain.RemoveAt(0);
                 _messageBroker.RaiseCommandReceived(this, newCommand);
             }
         }

--- a/Homero.Plugin.Pipe/PipeModule.cs
+++ b/Homero.Plugin.Pipe/PipeModule.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Ninject.Modules;
+
+namespace Homero.Plugin.Pipe
+{
+    public class PipeModule : NinjectModule
+    {
+        public override void Load()
+        {
+            Bind<IPlugin>().To<PipePlugin>();
+        }
+    }
+}

--- a/Homero.Plugin.Pipe/PipePlugin.cs
+++ b/Homero.Plugin.Pipe/PipePlugin.cs
@@ -25,20 +25,20 @@ namespace Homero.Plugin.Pipe
             IClient client = sender as IClient;
 
             PipeClient pipeClient = new PipeClient(client, _broker, e.Command);
-            List<string> commands = string.Join(" ", e.Command.Arguments).Split('|').ToList();
+            List<string> commandChain = string.Join(" ", e.Command.Arguments).Split('|').ToList();
 
-            for (int i = 0; i < commands.Count; i++)
+            for (int i = 0; i < commandChain.Count; i++)
             {
-                commands[i] = commands[i].Trim();
+                commandChain[i] = commandChain[i].Trim();
             }
             TextCommand firstCommand = new TextCommand()
             {
-                Arguments = commands[0].Split(' ').Skip(1).ToList(),
-                Command = commands[0].Split(' ')[0]
+                Arguments = commandChain[0].Split(' ').Skip(1).ToList(),
+                Command = commandChain[0].Split(' ')[0]
             };
 
-            commands.RemoveAt(0);
-            pipeClient._commandChain = commands;
+            commandChain.RemoveAt(0);
+            pipeClient._commandChain = commandChain;
             pipeClient.FireFirstMessage(firstCommand);
         }
 

--- a/Homero.Plugin.Pipe/PipePlugin.cs
+++ b/Homero.Plugin.Pipe/PipePlugin.cs
@@ -38,7 +38,7 @@ namespace Homero.Plugin.Pipe
             };
 
             commandChain.RemoveAt(0);
-            pipeClient._commandChain = commandChain;
+            pipeClient.CommandChain = commandChain;
             pipeClient.FireFirstMessage(firstCommand);
         }
 

--- a/Homero.Plugin.Pipe/PipePlugin.cs
+++ b/Homero.Plugin.Pipe/PipePlugin.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Homero.Client;
+using Homero.EventArgs;
+using Homero.Messages;
+using Homero.Services;
+
+namespace Homero.Plugin.Pipe
+{
+    public class PipePlugin : IPlugin
+    {
+        private List<string> commands = new List<string>() {"pip", "pipe"};
+        private IMessageBroker _broker;
+        public PipePlugin(IMessageBroker broker)
+        {
+            _broker = broker;
+            broker.CommandReceived += BrokerOnCommandReceived;
+        }
+
+        private void BrokerOnCommandReceived(object sender, CommandReceivedEventArgs e)
+        {
+            IClient client = sender as IClient;
+
+            PipeClient pipeClient = new PipeClient(client, _broker, e.Command);
+            List<string> commands = string.Join(" ", e.Command.Arguments).Split('|').ToList();
+
+            for (int i = 0; i < commands.Count; i++)
+            {
+                commands[i] = commands[i].Trim();
+            }
+            TextCommand firstCommand = new TextCommand()
+            {
+                Arguments = commands[0].Split(' ').Skip(1).ToList(),
+                Command = commands[0].Split(' ')[0]
+            };
+
+            commands.RemoveAt(0);
+            pipeClient._commandChain = commands;
+            pipeClient.FireFirstMessage(firstCommand);
+        }
+
+        public void Startup()
+        {
+        }
+
+        public void Shutdown()
+        {
+        }
+
+        public List<string> RegisteredTextCommands
+        {
+            get
+            {
+                return commands;
+            }
+        }
+    }
+}

--- a/Homero.Plugin.Pipe/Properties/AssemblyInfo.cs
+++ b/Homero.Plugin.Pipe/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Homero.Plugin.Pipe")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Homero.Plugin.Pipe")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("b9f15209-14fa-49c1-a5d9-1d15e676e8f3")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Homero.Plugin.Pipe/packages.config
+++ b/Homero.Plugin.Pipe/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Ninject" version="3.2.2.0" targetFramework="net46" />
+</packages>

--- a/Homero/Messages/ITextCommand.cs
+++ b/Homero/Messages/ITextCommand.cs
@@ -11,7 +11,7 @@ namespace Homero.Messages
         List<string> Arguments { get; }
     }
 
-    class TextCommand : ITextCommand
+    public class TextCommand : ITextCommand
     {
         public IStandardMessage InnerMessage { get; set; }
         public string Command { get; set; }

--- a/homeronet.sln
+++ b/homeronet.sln
@@ -15,6 +15,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Homero.Plugin.Circlejerk", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Homero.Plugin.Media", "Homero.Plugin.Media\Homero.Plugin.Media.csproj", "{E29BAFF4-C58F-483A-823A-30EA7D6E011D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Homero.Plugin.Pipe", "Homero.Plugin.Pipe\Homero.Plugin.Pipe.csproj", "{B9F15209-14FA-49C1-A5D9-1D15E676E8F3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -45,6 +47,10 @@ Global
 		{E29BAFF4-C58F-483A-823A-30EA7D6E011D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E29BAFF4-C58F-483A-823A-30EA7D6E011D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E29BAFF4-C58F-483A-823A-30EA7D6E011D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B9F15209-14FA-49C1-A5D9-1D15E676E8F3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B9F15209-14FA-49C1-A5D9-1D15E676E8F3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B9F15209-14FA-49C1-A5D9-1D15E676E8F3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B9F15209-14FA-49C1-A5D9-1D15E676E8F3}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Closes #61 

It could be cleaner but it works and works well. Right now it'll fail on plugins that do a ReplyTo on any other signature than Command/String but, we can solve that in a later PR.

Or we can add that to this PR and not accept it until I do that. On y'all.

It works by taking the command, then working out what commands to send out and it sends them out under a temporary IClient instance that takes all those ReplyTo calls and invokes the rest of the command chain with its own instance. After the command chain has been passed to, it sends that result to the original IClient that called the command. It's sneaky and it's fun! :clap: TOLD :clap: YALL :clap: CODING :clap: AGAINST :clap: INTERFACES :clap: ROCKS :clap: 
- [x] @Alligator 
- [x] @sponge 
